### PR TITLE
Gracefully continue on missing gcode filename

### DIFF
--- a/moonraker/components/timelapse.py
+++ b/moonraker/components/timelapse.py
@@ -214,7 +214,7 @@ class Timelapse:
             klippy_apis = self.server.lookup_component("klippy_apis")
             kresult = await klippy_apis.query_objects({'print_stats': None})
             pstats = kresult.get("print_stats", {})
-            gcodefile = pstats.get("filename", "").split("/")[-1]
+            gcodefile = pstats.get("filename", "").rsplit("/", 1)[-1]
 
             # variable framerate
             if self.variablefps:


### PR DESCRIPTION
I'm not sure why, but I can't get a timelapse to render, and loading a g-code through M23 calls `timelapse_cleanup` deleting the frames from a prior print.

In general however, this will gracefully handle a missing filename, or multiple slashes in a gcode filename (subdirectories).