### PR TITLE
Improve encoding process reliability

### DIFF
--- a/moonraker/components/timelapse.py
+++ b/moonraker/components/timelapse.py
@@ -232,6 +232,7 @@ class Timelapse:
             cmd = self.ffmpeg_binary_path \
                 + " -r " + str(fps) \
                 + " -i '" + inputfiles + "'" \
+                + " -threads 2 -g 5" \
                 + " -crf " + str(self.crf) \
                 + " -vcodec libx264" \
                 + " -pix_fmt " + self.pixelformat \


### PR DESCRIPTION
+ Add -threads 2  to limit overall CPU usage when encoding timelapse video.
+ Add -g 5 to prevent ffmpeg being killed (taken from octoprint forum https://github.com/OctoPrint/OctoPrint/issues/3972/)

Signed-off-by: Henky Prayoga <henky.prayoga@callysta-engineering.com>